### PR TITLE
refactor: dto 이름 규칙 변경/test: 사용자 인증 시 access token cookie 사용

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -97,6 +97,7 @@ export class AuthController {
   })
   @HttpCode(204)
   @UseGuards(AccessTokenGuard)
+  @UseGuards(RefreshTokenGuard)
   @Post('logout')
   async logout(@Req() req: TokenGuardReq, @Res({ passthrough: true }) res: Response) {
     const refreshToken = req.cookies.refresh_token;

--- a/src/review/dto/create-review-res.dto.ts
+++ b/src/review/dto/create-review-res.dto.ts
@@ -1,3 +1,0 @@
-import { ReviewResDto } from '@/review/dto/review-res.dto';
-
-export class CreateReviewResDto extends ReviewResDto {}

--- a/src/review/dto/find-review-res.dto.ts
+++ b/src/review/dto/find-review-res.dto.ts
@@ -1,3 +1,0 @@
-import { ReviewResDto } from '@/review/dto/review-res.dto';
-
-export class FindReviewResDto extends ReviewResDto {}

--- a/src/review/dto/review.dto.ts
+++ b/src/review/dto/review.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Type } from 'class-transformer';
 import { IsString, IsNotEmpty, IsNumber, IsDate } from 'class-validator';
 
-export class ReviewResDto {
+export class ReviewDto {
   @ApiProperty({
     description: 'The unique identifier of the review',
     example: 1

--- a/src/review/dto/reviews.dto.ts
+++ b/src/review/dto/reviews.dto.ts
@@ -2,18 +2,18 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Type } from 'class-transformer';
 import { IsNotEmpty, ValidateNested } from 'class-validator';
 
-import { ReviewResDto } from '@/review/dto/review-res.dto';
+import { ReviewDto } from '@/review/dto/review.dto';
 import { ReviewMetaDto } from '@/review/dto/reviews-meta.dto';
 
-export class FindReviewsResDto {
+export class ReviewsDto {
   @ApiProperty({
-    type: [ReviewResDto]
+    type: [ReviewDto]
   })
   @IsNotEmpty()
   @Expose()
-  @Type(() => ReviewResDto)
+  @Type(() => ReviewDto)
   @ValidateNested()
-  reviews: ReviewResDto[];
+  reviews: ReviewDto[];
 
   @ApiProperty()
   @IsNotEmpty()

--- a/src/review/dto/update-review-res.dto.ts
+++ b/src/review/dto/update-review-res.dto.ts
@@ -1,3 +1,0 @@
-import { ReviewResDto } from '@/review/dto/review-res.dto';
-
-export class UpdateReviewResDto extends ReviewResDto {}

--- a/src/review/review.controller.spec.ts
+++ b/src/review/review.controller.spec.ts
@@ -5,12 +5,10 @@ import { DeepMockProxy, mockDeep } from 'jest-mock-extended';
 
 import { REVIEWS_PAGE_SIZE } from '@/constants/review';
 import { PrismaService } from '@/prisma/prisma.service';
-import { CreateReviewResDto } from '@/review/dto/create-review-res.dto';
 import { CreateReviewDto } from '@/review/dto/create-review.dto';
-import { FindReviewResDto } from '@/review/dto/find-review-res.dto';
-import { FindReviewsResDto } from '@/review/dto/find-reviews-res.dto';
 import { FindReviewsDto } from '@/review/dto/find-reviews.dto';
-import { UpdateReviewResDto } from '@/review/dto/update-review-res.dto';
+import { ReviewDto } from '@/review/dto/review.dto';
+import { ReviewsDto } from '@/review/dto/reviews.dto';
 import { UpdateReviewDto } from '@/review/dto/update-review.dto';
 import { ReviewService } from '@/review/review.service';
 import { getMockReview } from '@/utils/unit-test';
@@ -44,7 +42,7 @@ describe('ReviewController', () => {
   });
 
   describe('create', () => {
-    it('should return an instance of CreateReviewResDto', async () => {
+    it('should return an instance of ReviewDto', async () => {
       const review = getMockReview();
       const req = {
         id: review.userId
@@ -52,7 +50,7 @@ describe('ReviewController', () => {
       const body: CreateReviewDto = { text: review.text, rating: review.rating };
       service.create.mockResolvedValue(review);
       const result = await controller.create(req, body, review.productId);
-      expect(result).toBeInstanceOf(CreateReviewResDto);
+      expect(result).toBeInstanceOf(ReviewDto);
     });
   });
 
@@ -69,19 +67,19 @@ describe('ReviewController', () => {
   });
 
   describe('findOne', () => {
-    it('should return an instance of FindReviewResDto', async () => {
+    it('should return an instance of ReviewDto', async () => {
       const review = getMockReview();
       const req = {
         id: review.userId
       } as TokenGuardReq;
       service.findOne.mockResolvedValue(review);
       const result = await controller.findOne(req, review.productId, review.id);
-      expect(result).toBeInstanceOf(FindReviewResDto);
+      expect(result).toBeInstanceOf(ReviewDto);
     });
   });
 
   describe('findMany', () => {
-    it('should return an instance of FindReviewsResDto', async () => {
+    it('should return an instance of ReviewsDto', async () => {
       const review = getMockReview();
       const sortBy: SortBy = 'createdAt';
       const orderBy: OrderBy = 'desc';
@@ -93,12 +91,12 @@ describe('ReviewController', () => {
       service.findMany.mockResolvedValue(reviewsData);
       const getReviewsDto: FindReviewsDto = { sortBy, orderBy, page };
       const result = await controller.findMany(review.productId, getReviewsDto);
-      expect(result).toBeInstanceOf(FindReviewsResDto);
+      expect(result).toBeInstanceOf(ReviewsDto);
     });
   });
 
   describe('update', () => {
-    it('should return an instance of UpdateReviewResDto', async () => {
+    it('should return an instance of ReviewDto', async () => {
       const review = getMockReview();
       const req = {
         id: review.userId
@@ -109,7 +107,7 @@ describe('ReviewController', () => {
       };
       service.update.mockResolvedValue(review);
       const result = await controller.update(req, updateReviewDto, review.productId, review.id);
-      expect(result).toBeInstanceOf(UpdateReviewResDto);
+      expect(result).toBeInstanceOf(ReviewDto);
     });
   });
 });

--- a/src/review/review.controller.ts
+++ b/src/review/review.controller.ts
@@ -16,12 +16,10 @@ import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { plainToInstance } from 'class-transformer';
 
 import { AccessTokenGuard } from '@/auth/guard/access-token.guard';
-import { CreateReviewResDto } from '@/review/dto/create-review-res.dto';
 import { CreateReviewDto } from '@/review/dto/create-review.dto';
-import { FindReviewResDto } from '@/review/dto/find-review-res.dto';
-import { FindReviewsResDto } from '@/review/dto/find-reviews-res.dto';
 import { FindReviewsDto } from '@/review/dto/find-reviews.dto';
-import { UpdateReviewResDto } from '@/review/dto/update-review-res.dto';
+import { ReviewDto } from '@/review/dto/review.dto';
+import { ReviewsDto } from '@/review/dto/reviews.dto';
 import { UpdateReviewDto } from '@/review/dto/update-review.dto';
 import { ReviewService } from '@/review/review.service';
 
@@ -38,7 +36,7 @@ export class ReviewController {
   @ApiResponse({
     status: 201,
     description: 'created',
-    type: CreateReviewResDto
+    type: ReviewDto
   })
   @ApiResponse({
     status: 400,
@@ -60,7 +58,7 @@ export class ReviewController {
     @Param('productId', ParseIntPipe) productId: number
   ) {
     const review = await this.reviewService.create(createReviewDto, id, productId);
-    return plainToInstance(CreateReviewResDto, review);
+    return plainToInstance(ReviewDto, review);
   }
 
   @ApiOperation({
@@ -99,7 +97,7 @@ export class ReviewController {
   @ApiResponse({
     status: 200,
     description: 'Success',
-    type: FindReviewResDto
+    type: ReviewDto
   })
   @ApiResponse({
     status: 401,
@@ -121,7 +119,7 @@ export class ReviewController {
     @Param('id', ParseIntPipe) reviewId: number
   ) {
     const review = await this.reviewService.findOne(req.id, productId, reviewId);
-    return plainToInstance(FindReviewResDto, review);
+    return plainToInstance(ReviewDto, review);
   }
 
   @ApiOperation({
@@ -130,7 +128,7 @@ export class ReviewController {
   @ApiResponse({
     status: 200,
     description: 'Success',
-    type: FindReviewsResDto
+    type: ReviewsDto
   })
   @ApiResponse({
     status: 400,
@@ -146,7 +144,7 @@ export class ReviewController {
     @Query() findReviewsDto: FindReviewsDto
   ) {
     const reviews = await this.reviewService.findMany(findReviewsDto, productId);
-    return plainToInstance(FindReviewsResDto, reviews);
+    return plainToInstance(ReviewsDto, reviews);
   }
 
   @ApiOperation({
@@ -155,7 +153,7 @@ export class ReviewController {
   @ApiResponse({
     status: 200,
     description: 'Success',
-    type: UpdateReviewResDto
+    type: ReviewDto
   })
   @ApiResponse({
     status: 400,
@@ -187,6 +185,6 @@ export class ReviewController {
       id: reviewId,
       updateReviewDto
     });
-    return plainToInstance(UpdateReviewResDto, review);
+    return plainToInstance(ReviewDto, review);
   }
 }

--- a/src/user/dto/user.dto.ts
+++ b/src/user/dto/user.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 import { IsNotEmpty, IsString } from 'class-validator';
 
-export class FindUserResDto {
+export class UserDto {
   @ApiProperty({
     description: 'User ID',
     example: '1234567890'

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -4,7 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Response } from 'express';
 import { DeepMockProxy, mockDeep } from 'jest-mock-extended';
 
-import { FindUserResDto } from '@/user/dto/find-user-res.dto';
+import { UserDto } from '@/user/dto/user.dto';
 import { UserService } from '@/user/user.service';
 
 import { UserController } from './user.controller';
@@ -37,7 +37,7 @@ describe('UserController', () => {
   });
 
   describe('findOne', () => {
-    it('should return an instance of FindUserResDto', async () => {
+    it('should return an instance of UserDto', async () => {
       const req = {
         id: '1234567890'
       } as TokenGuardReq;
@@ -51,7 +51,7 @@ describe('UserController', () => {
       };
       service.findOne.mockResolvedValue(userInfo);
       const result = await controller.findOne(req);
-      expect(result).toBeInstanceOf(FindUserResDto);
+      expect(result).toBeInstanceOf(UserDto);
     });
   });
 

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -4,7 +4,8 @@ import { plainToInstance } from 'class-transformer';
 import { Response } from 'express';
 
 import { AccessTokenGuard } from '@/auth/guard/access-token.guard';
-import { FindUserResDto } from '@/user/dto/find-user-res.dto';
+import { RefreshTokenGuard } from '@/auth/guard/refresh-token.guard';
+import { UserDto } from '@/user/dto/user.dto';
 import { UserService } from '@/user/user.service';
 
 import { TokenGuardReq } from '@/types/refreshTokenGuard.type';
@@ -20,7 +21,7 @@ export class UserController {
   @ApiResponse({
     status: 200,
     description: 'Success',
-    type: FindUserResDto
+    type: UserDto
   })
   @ApiResponse({
     status: 401,
@@ -28,10 +29,11 @@ export class UserController {
   })
   @HttpCode(200)
   @UseGuards(AccessTokenGuard)
+  @UseGuards(RefreshTokenGuard)
   @Get('')
   async findOne(@Req() req: TokenGuardReq) {
     const user = await this.userService.findOne(req.id, req.cookies.refresh_token);
-    return plainToInstance(FindUserResDto, user);
+    return plainToInstance(UserDto, user);
   }
 
   @ApiOperation({
@@ -47,6 +49,7 @@ export class UserController {
   })
   @HttpCode(204)
   @UseGuards(AccessTokenGuard)
+  @UseGuards(RefreshTokenGuard)
   @Delete('')
   async delete(@Req() req: TokenGuardReq, @Res({ passthrough: true }) res: Response) {
     const refreshToken = req.cookies.refresh_token;

--- a/src/utils/integration-test.ts
+++ b/src/utils/integration-test.ts
@@ -33,9 +33,9 @@ const createTestingApp = async <T>(modules: Type<T>[]) => {
   return app;
 };
 
-const validateResDto = async (ResDto: ClassConstructor<object>, body: object) => {
-  const dto = plainToInstance(ResDto, body);
-  const errors = await validate(dto, {
+const validateDto = async (dto: ClassConstructor<object>, obj: object) => {
+  const instance = plainToInstance(dto, obj);
+  const errors = await validate(instance, {
     whitelist: true,
     forbidNonWhitelisted: true
   });
@@ -71,7 +71,8 @@ const createUser = async (app: INestApplication, id: string) => {
   const res = await request(app.getHttpServer()).post('/api/auth/login').send(loginDto);
   const cookies = res.get('Set-Cookie');
   const refreshTokenCookie = cookies.find(cookie => cookie.startsWith('refresh_token='));
-  return { refreshTokenCookie, kakaoUser };
+  const accessTokenCookie = cookies.find(cookie => cookie.startsWith('access_token='));
+  return { accessTokenCookie, refreshTokenCookie, kakaoUser };
 };
 
 const deleteUser = async (prismaService: PrismaService, id: string) => {
@@ -119,7 +120,7 @@ const createReview = async (
 
 export {
   createTestingApp,
-  validateResDto,
+  validateDto,
   mockKakaoLogin,
   createUser,
   deleteUser,

--- a/test/controller/auth.integration-spec.ts
+++ b/test/controller/auth.integration-spec.ts
@@ -12,7 +12,7 @@ import {
   createUser,
   deleteUser,
   mockKakaoLogin,
-  validateResDto
+  validateDto
 } from '@/utils/integration-test';
 
 describe('AuthController (integration)', () => {
@@ -34,7 +34,7 @@ describe('AuthController (integration)', () => {
       mockKakaoLogin(kakaoLoginService, id);
       const res = await request(app.getHttpServer()).post('/api/auth/login').send(req).expect(201);
 
-      validateResDto(LoginResDto, res.body);
+      validateDto(LoginResDto, res.body);
 
       const cookies = res.get('Set-Cookie');
       const accessTokenCookie = cookies.find(cookie => cookie.startsWith('access_token='));
@@ -62,22 +62,22 @@ describe('AuthController (integration)', () => {
 
   describe('/api/auth/logout (POST)', () => {
     it('204', async () => {
-      const { refreshTokenCookie } = await createUser(app, id);
+      const { accessTokenCookie, refreshTokenCookie } = await createUser(app, id);
 
       KakaoLoginService.logout = jest.fn().mockResolvedValue({
         id
       });
       const res = await request(app.getHttpServer())
         .post('/api/auth/logout')
-        .set('Cookie', [refreshTokenCookie])
+        .set('Cookie', [accessTokenCookie, refreshTokenCookie])
         .expect(204);
       const cookies = res.get('Set-Cookie');
-      const accessTokenCookie = cookies.find(cookie => cookie.startsWith('access_token='));
-      expect(accessTokenCookie).toBeDefined();
-      expect(accessTokenCookie).toContain('HttpOnly');
-      expect(accessTokenCookie).toContain('Secure');
-      expect(accessTokenCookie).toContain('SameSite=Strict');
-      const expires = accessTokenCookie.match(/expires=([^;]+);?/);
+      const resAccessTokenCookie = cookies.find(cookie => cookie.startsWith('access_token='));
+      expect(resAccessTokenCookie).toBeDefined();
+      expect(resAccessTokenCookie).toContain('HttpOnly');
+      expect(resAccessTokenCookie).toContain('Secure');
+      expect(resAccessTokenCookie).toContain('SameSite=Strict');
+      const expires = resAccessTokenCookie.match(/expires=([^;]+);?/);
       expect(expires).toBeDefined();
 
       if (expires) {

--- a/test/controller/product.integration-spec.ts
+++ b/test/controller/product.integration-spec.ts
@@ -10,7 +10,7 @@ import {
   createProduct,
   createTestingApp,
   deleteProduct,
-  validateResDto
+  validateDto
 } from '@/utils/integration-test';
 
 describe('ProductController (integration)', () => {
@@ -42,7 +42,7 @@ describe('ProductController (integration)', () => {
       const { body } = await request(app.getHttpServer())
         .get('/api/products?page=1&query=apple')
         .expect(200);
-      validateResDto(ProductsDto, body);
+      validateDto(ProductsDto, body);
 
       await deleteProduct(prismaService, product.id);
     });

--- a/test/controller/search.integration-spec.ts
+++ b/test/controller/search.integration-spec.ts
@@ -10,7 +10,7 @@ import {
   createProduct,
   createTestingApp,
   deleteProduct,
-  validateResDto
+  validateDto
 } from '@/utils/integration-test';
 
 describe('SearchController (integration)', () => {
@@ -42,7 +42,7 @@ describe('SearchController (integration)', () => {
       const { body } = await request(app.getHttpServer())
         .get('/api/search?query=apple')
         .expect(200);
-      validateResDto(SearchResDto, body);
+      validateDto(SearchResDto, body);
 
       await deleteProduct(prismaService, product.id);
     });


### PR DESCRIPTION
## 작업 내용
- refactor: dto 이름 규칙 변경
- test: 사용자 인증 시 access token cookie 사용
  - [#56](https://github.com/Slime-Project/MODU-BE/pull/56) 원인으로 발생한 테스트 버그 수정
  -> husky 설정 변경 예정(변경 사항에 대해서만 테스트 -> 전체 테스트)