### PR TITLE
feat: KakaoLoginService - 유저 프로필(인증 없이) 가져오기

### DIFF
--- a/src/kakao/login/kakao-login.service.ts
+++ b/src/kakao/login/kakao-login.service.ts
@@ -58,7 +58,7 @@ export class KakaoLoginService {
     return plainToInstance(ReissueTokenDto, data, { excludeExtraneousValues: true });
   }
 
-  static async getUserInfo(accessToken: string) {
+  static async getMyInfo(accessToken: string) {
     const userInfoUrl = 'https://kapi.kakao.com/v2/user/me';
     const { data } = await axios.get(userInfoUrl, {
       headers: {
@@ -66,6 +66,22 @@ export class KakaoLoginService {
         'Content-Type': 'application/x-www-form-urlencoded'
       },
       params: {
+        property_keys: JSON.stringify(['kakao_account.profile'])
+      }
+    });
+    return plainToInstance(KaKaoUserInfoDto, data, { excludeExtraneousValues: true });
+  }
+
+  async getUserInfo(id: number) {
+    const userInfoUrl = 'https://kapi.kakao.com/v2/user/me';
+    const { data } = await axios.get(userInfoUrl, {
+      headers: {
+        Authorization: `KakaoAK ${this.configService.get('KAKAO_ADMIN_KEY')}`,
+        'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8'
+      },
+      params: {
+        target_id_type: 'user_id',
+        target_id: id,
         property_keys: JSON.stringify(['kakao_account.profile'])
       }
     });
@@ -92,7 +108,7 @@ export class KakaoLoginService {
 
   async login(code: string) {
     const token = await this.getToken(code);
-    const user = await KakaoLoginService.getUserInfo(token.accessToken);
+    const user = await KakaoLoginService.getMyInfo(token.accessToken);
     return {
       token,
       user

--- a/src/types/kakao.type.ts
+++ b/src/types/kakao.type.ts
@@ -15,6 +15,18 @@ type ReissueTokenRes = {
   refresh_token_expires_in?: number;
 };
 
+type KakaoAccount = {
+  profile_nickname_needs_agreement: boolean;
+  profile_image_needs_agreement: boolean;
+  profile: {
+    nickname: string;
+    thumbnail_image_url: string;
+    profile_image_url: string;
+    is_default_image: boolean;
+    is_default_nickname: boolean;
+  };
+};
+
 type UserInfoRes = {
   id: number;
   connected_at?: string; // ISO string
@@ -23,17 +35,13 @@ type UserInfoRes = {
     profile_image: string;
     thumbnail_image: string;
   };
-  kakao_account: {
-    profile_nickname_needs_agreement: boolean;
-    profile_image_needs_agreement: boolean;
-    profile: {
-      nickname: string;
-      thumbnail_image_url: string;
-      profile_image_url: string;
-      is_default_image: boolean;
-      is_default_nickname: boolean;
-    };
-  };
+  kakao_account: KakaoAccount;
 };
 
-export { GetTokenRes, ReissueTokenRes, UserInfoRes };
+type UsersRes = {
+  id: number;
+  connected_at?: string; // ISO string
+  kakao_account: KakaoAccount;
+}[];
+
+export { GetTokenRes, ReissueTokenRes, UserInfoRes, UsersRes };

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -44,7 +44,7 @@ describe('UserService', () => {
       };
 
       prismaService.auth.findUnique.mockResolvedValue(mockAuth);
-      KakaoLoginService.getUserInfo = jest.fn().mockResolvedValue(kakaoUser);
+      KakaoLoginService.getMyInfo = jest.fn().mockResolvedValue(kakaoUser);
       const result = await userService.findOne(mockAuth.userId, mockAuth.refreshToken);
       expect(result).toEqual(userInfo);
     });

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -60,7 +60,7 @@ export class UserService {
       throw new UnauthorizedException('Invalid or expired refresh token');
     }
 
-    const kakaoUserInfo = await KakaoLoginService.getUserInfo(auth.kakaoAccessToken);
+    const kakaoUserInfo = await KakaoLoginService.getMyInfo(auth.kakaoAccessToken);
     const userInfo: UserInfo = {
       id,
       role: UserRole.USER,

--- a/src/utils/unit-test.ts
+++ b/src/utils/unit-test.ts
@@ -5,6 +5,7 @@ import { PRODUCTS_PAGE_SIZE } from '@/constants/page';
 import { REVIEW_IMGS_PAGE_SIZE } from '@/constants/review-img';
 import { KaKaoUserInfoDto } from '@/kakao/login/dto/kakao-user-info.dto';
 
+import { UserInfoRes, UsersRes } from '@/types/kakao.type';
 import {
   ReviewImgsData,
   ReviewImgWithReview,
@@ -18,15 +19,42 @@ import {
 } from '@/types/review.type';
 import { Profile, UserInfo } from '@/types/user.type';
 
-const profileMock: Profile = {
-  nickname: 'nickname',
-  profileImg: 'url'
+const kakaoUsersResMock: UsersRes = [
+  {
+    id: 1,
+    connected_at: new Date().toISOString(),
+    kakao_account: {
+      profile_nickname_needs_agreement: false,
+      profile_image_needs_agreement: false,
+      profile: {
+        nickname: 'nickname',
+        thumbnail_image_url: 'url',
+        profile_image_url: 'url',
+        is_default_image: true,
+        is_default_nickname: false
+      }
+    }
+  }
+];
+
+const kakaoUserInfoResMock: UserInfoRes = {
+  ...kakaoUsersResMock[0],
+  properties: {
+    nickname: 'nickname',
+    profile_image: 'url',
+    thumbnail_image: 'url'
+  }
 };
 
 const kakaoUserInfoDtoMock: KaKaoUserInfoDto = {
-  id: '1',
-  nickname: 'nickname',
-  profileImg: 'url'
+  id: kakaoUserInfoResMock.id.toString(),
+  nickname: kakaoUserInfoResMock.properties.nickname,
+  profileImg: kakaoUserInfoResMock.properties.profile_image
+};
+
+const profileMock: Profile = {
+  nickname: kakaoUserInfoDtoMock.nickname,
+  profileImg: kakaoUserInfoDtoMock.profileImg
 };
 
 const mockUser: UserInfo = {
@@ -183,6 +211,8 @@ const mockNaverRes = {
 };
 
 export {
+  kakaoUsersResMock,
+  kakaoUserInfoResMock,
   mockAuth,
   mockProduct,
   getMockWishlistItem,

--- a/test/controller/user.integration-spec.ts
+++ b/test/controller/user.integration-spec.ts
@@ -22,7 +22,7 @@ describe('UserController (integration)', () => {
       const id = '4';
       const { accessTokenCookie, refreshTokenCookie, kakaoUser } = await createUser(app, id);
 
-      KakaoLoginService.getUserInfo = jest.fn().mockResolvedValue(kakaoUser);
+      KakaoLoginService.getMyInfo = jest.fn().mockResolvedValue(kakaoUser);
       const { body } = await request(app.getHttpServer())
         .get('/api/user')
         .set('Cookie', [accessTokenCookie, refreshTokenCookie])


### PR DESCRIPTION
## 연관된 이슈
MODU-101

## 작업 내용
KakaoLoginService
- getMyInfo <- getUserInfo 이름 변경
- getUserInfo: 인증 없이 사용자 정보 가져오기
- getMyInfo와 getUserInfo로 분리 이유: myInfo는 비공개 정보를 포함하게 될 수 있기 때문